### PR TITLE
Fix issue 306

### DIFF
--- a/src/main/proguard/multibit-exe.pro
+++ b/src/main/proguard/multibit-exe.pro
@@ -9,20 +9,20 @@
 -injars  ../../../target/multibit-exe-full.jar
 -outjars ../../../target/multibit-exe.jar
 
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/rt.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/alt-rt.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/charsets.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/jce.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/jfr.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/JObjC.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/jsse.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/management-agent.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/dnsns.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/localedata.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/sunec.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/sunjce_provider.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/sunpkcs11.jar
--libraryjars ../skeleton/mac/MultiBit.app/Contents/Plugins/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/zipfs.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/rt.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/alt-rt.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/charsets.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/jce.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/jfr.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/JObjC.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/jsse.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/management-agent.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/dnsns.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/localedata.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/sunec.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/sunjce_provider.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/sunpkcs11.jar
+-libraryjars ../skeleton/mac/MultiBit.app/Contents/PlugIns/jdk1.7.0_25.jdk/Contents/Home/jre/lib/ext/zipfs.jar
 
 # Save the obfuscation mapping to a file, so you can de-obfuscate any stack
 # traces later on. Keep a fixed source file attribute and all line number


### PR DESCRIPTION
Fixes problem where building on Linux will fail because the Mac JRE plugins dir has invalid case in its name - it should be 'PlugIns' instead of 'Plugins'.
