### PR TITLE
Turn grouping off with numberFormatNotLocalised

### DIFF
--- a/src/main/java/org/multibit/Localiser.java
+++ b/src/main/java/org/multibit/Localiser.java
@@ -109,6 +109,7 @@ public class Localiser {
         numberFormat.setMaximumFractionDigits(NUMBER_OF_FRACTION_DIGITS_FOR_BITCOIN);
         numberFormatNotLocalised = NumberFormat.getInstance(Locale.ENGLISH);
         numberFormatNotLocalised.setMaximumFractionDigits(NUMBER_OF_FRACTION_DIGITS_FOR_BITCOIN);
+        numberFormatNotLocalised.setGroupingUsed(false);
         
         decimalFormatSymbols = new java.text.DecimalFormatSymbols(locale);
     }


### PR DESCRIPTION
Sets grouping symbols (,) off when using numberFormatNotLocalised to fix the problem with errors when sending 1000 or more bitcoins.

Fixes #230
