### PR TITLE
In file PrivateKeysHandler.java we can see that KeyCrypterOpenSSL is uti...

### DIFF
--- a/src/main/java/org/multibit/crypto/KeyCrypterOpenSSL.java
+++ b/src/main/java/org/multibit/crypto/KeyCrypterOpenSSL.java
@@ -64,7 +64,7 @@ public class KeyCrypterOpenSSL {
     /**
      * number of times the password & salt are hashed during key creation.
      */
-    private static final int NUMBER_OF_ITERATIONS = 1024;
+    private static final int NUMBER_OF_ITERATIONS = 8192;
 
     /**
      * Key length.


### PR DESCRIPTION
...lised as an encryption function to secure a wallet.

Within KeyCrypterOpenSSL we can see that this encryption is performed utilising a manner compatible with OpenSSL's "enc" command, and therefore defined here:

http://www.openssl.org/docs/crypto/EVP_BytesToKey.html

Whilst the use of a salt and keystretching system is useful, a current discussion relevant to this may be seen in iSEC's recent security audit of Truecrypt. This audit, which has been well regarded in security circles, states:
"The iteration count used by TrueCrypt is either 1000 or 2000, depending on the hash function and use case.
In both cases, this iteration count is too small to prevent password guessing attacks for even moderately complex passwords."

Whilst better hash algorithms such as scrypt() would present a longer term solution, the longer term compatability requirements may take longer to evaluate. In the meantime, I recommend an increase to the work power. As the number utilised in this patch is lower than the iOS 4.x default of 10,000 it is not believed to be capable of causing any performance difficulties.
