### PR TITLE
Create a docker image for verifiable builds of executable JAR files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/java/maven:11u9-zulu-debian10
+
+RUN apt update && apt install -y git
+RUN mkdir /src /build
+ADD pom.xml /pom.xml
+ADD src /src
+# RUN cd /src; git clone https://github.com/Multibit-Legacy/multibit.git
+RUN mvn package -Dmaven.test.skip=true
+RUN cp -prv target/multibit-exe.jar /build/
+
+ENTRYPOINT echo $(ls -lh target/multibit-exe.jar)

--- a/docker.md
+++ b/docker.md
@@ -7,11 +7,31 @@ This is useful for recovering old
 Bitcoin wallets, exporting private keys, and importing it
 into a supported wallet, including Bitcoin forks.
 
-## Instructions
+You can build the image from scratch, or pull a pre-built
+image from DockerHub, then continue to the last section
+for copying out the built Java JAR executable.
+
+## Instructions for Building
+
+If you'd like to build this from scratch after
+examining `Dockerfile`:
 
 ```
-docker build . -t multibit:0.5.19
+docker build . -t <your_login>/multibit:0.5.19
+```
+
+## Instructions for Pulling
+
+```
+docker pull cryptogoth/multibit:0.5.19
+```
+
+## Instructions for Running Executable
+
+```
 docker create -ti --name dummy multibit:0.5.19 bash
 docker cp dummy:/target/multibit-exe.jar .
 java -jar .\multibit-exe.jar
 ```
+
+Enjoy.

--- a/docker.md
+++ b/docker.md
@@ -1,0 +1,17 @@
+# Building MultiBit Classic in Docker
+
+The included `Dockerfile` allows verifiable building of the
+last release of MultiBit Classic.
+
+This is useful for recovering old
+Bitcoin wallets, exporting private keys, and importing it
+into a supported wallet, including Bitcoin forks.
+
+## Instructions
+
+```
+docker build . -t multibit:0.5.19
+docker create -ti --name dummy multibit:0.5.19 bash
+docker cp dummy:/target/multibit-exe.jar .
+java -jar .\multibit-exe.jar
+```

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.multibit</groupId>
     <artifactId>multibit</artifactId>
-    <version>0.5.19</version>
+    <version>0.5.18</version>
     <name>MultiBit</name>
     <description>A Java Swing client for Bitcoin</description>
     <url>https://multibit.org</url>
@@ -253,10 +253,10 @@
                                             com.google.protobuf:protobuf-java:2.4.1:jar:null:compile:0c589509ec6fd86d5d2fda37e07c08538235d3b9
                                         </urn>
                                         <urn>
-                                            com.google.zxing:core:1.6:jar:null:compile:f6d1452ca591861d139c8d5b82a75444b7c2434a
+                                            com.google.zxing:core:1.7:jar:null:compile:f6d1452ca591861d139c8d5b82a75444b7c2434a
                                         </urn>
                                         <urn>
-                                            com.google.zxing:javase:1.6:jar:null:compile:a247611f2d7decb734c6eb796b02b902341312e3
+                                            com.google.zxing:javase:1.7:jar:null:compile:a247611f2d7decb734c6eb796b02b902341312e3
                                         </urn>
                                         <urn>
                                             com.lambdaworks:scrypt:1.3.2:jar:null:compile:b144d80b2b915a900730dd156ae749a88c0e2555
@@ -415,7 +415,7 @@
         <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>javase</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Builds of MultiBit Classic are not available as the https://multibit.org website redirects to the Multibit-Legacy Github repo and releases are not enabled. This makes it hard for users to recover their old key files, especially for exporting their private key for import into another wallet.

This PR adds a Dockerfile for such a verifiable build, with instructions on how to use it.